### PR TITLE
Background around footer doesn't match section above

### DIFF
--- a/index.php
+++ b/index.php
@@ -136,8 +136,9 @@ if ( $i > 6 ) {
 } //$i > 6
 ?>
 
-	</div>
 </div>
+<!--closes WRAP-REGULAR-->
+
 
 <script>
 $(document).ready(function() {


### PR DESCRIPTION
Tagging @frrrances for code-review: removes closing <div> causing background mismatch; add comment; fixes #67.