### PR TITLE
[WIP] Rebuilds theme to load posts from API

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,7 +4,7 @@
 	Description: A Wordpress child theme that descends from mitlibraries-parent
 	Author: Design by Moth Design, development by MIT Libraries
 	Template: libraries
-	Version: 1.5.0-@@branch-@@commit;
+	Version: 2.0.0-@@branch-@@commit;
 */
 
 @import url("../libraries/style.css");

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
 	Description: A Wordpress child theme that descends from mitlibraries-parent
 	Author: Design by Moth Design, development by MIT Libraries
 	Template: libraries
-	Version: 1.5.0-@@branch-@@commit;
+	Version: 2.0.0-@@branch-@@commit;
 
 News theme built for the MIT Libraries.
 


### PR DESCRIPTION
This will be version 2 of the News theme - which involves a significant restructuring. Posts will no longer be loaded via PHP on page load, but instead called from WordPress' coming API.

I _know_ I'm going to need review from @frrrances. Others may also need to weight in at times.

Please note: this work is being organized using a release branch approach - so commits should not be made against this branch directly. New work should be contributed using feature branches and pull requests.