### PR TITLE
Adds API support to all pages

### DIFF
--- a/additionalPosts-biblio.php
+++ b/additionalPosts-biblio.php
@@ -62,7 +62,7 @@ $("#another").hide();
 </script>
 
 
-<?php } // End if(). ?>
+<?php } ?>
 	
 	
 	

--- a/additionalPosts-cat.php
+++ b/additionalPosts-cat.php
@@ -68,9 +68,7 @@ $ajaxLength = $the_query->post_count;
 <script>
 $("#another").hide();
 </script>
-<?php }
-// End if().
-?>
+<?php } ?>
 	
 <?php if ( $the_query->have_posts() ) :  ?>
 
@@ -86,7 +84,7 @@ while ( $the_query->have_posts() ) : $the_query->the_post();
 
 <?php if ( get_post_type( get_the_ID() ) == 'bibliotech' ) { ?>
 		   
-			<?php } // End if(). ?>
+			<?php } ?>
 			  
 					<?php  wp_reset_query(); // Restore global post data stomped by the_post(). ?>
 		   

--- a/additionalPosts-search.php
+++ b/additionalPosts-search.php
@@ -55,7 +55,7 @@ foreach ( $query_args as $key => $string ) {
 	if ( 'search' == $query_split[0] ) {
 	$search_args['s'] = urldecode( $query_split[1] );
 	}
-} // End foreach().
+}
 
 $the_query = new WP_Query( $search_args );
 // The set_search() function is defined above.

--- a/archive.php
+++ b/archive.php
@@ -20,15 +20,12 @@
 get_header();
 $date = DateTime::createFromFormat( 'Ymd', get_field( 'event_date' ) );
 
+get_template_part( 'inc/sub-header' );
 
+if ( (get_post_type( get_the_ID() ) === 'bibliotech') || (cat_is_ancestor_of( 73, $cat ) or is_category( 73 )) ) {
+	get_template_part( 'inc/bib-header' );
+}
 ?>
-<?php get_template_part( 'inc/sub-header' ); ?>
-<?php
-if ( (get_post_type( get_the_ID() ) == 'bibliotech') || (cat_is_ancestor_of( 73, $cat ) or is_category( 73 )) ) {  ?>
-<?php get_template_part( 'inc/bib-header' ); ?>
-<?php  } ?>
-
-
 
 <section id="" class="site-content">
 	<div id="content" role="main">
@@ -36,7 +33,7 @@ if ( (get_post_type( get_the_ID() ) == 'bibliotech') || (cat_is_ancestor_of( 73,
 	
 	<!-- .archive-header -->
 	<div class="container">
-	<div class="row">
+	<div class="row" id="mitlibnews-container" data-postcontent="issue" data-postissue="<?php echo esc_attr( get_queried_object()->slug ); ?>">
 	
 	
 	  <?php

--- a/category.php
+++ b/category.php
@@ -8,8 +8,6 @@
 
 get_header();
 
-
-
 $date = DateTime::createFromFormat( 'Ymd', get_field( 'event_date' ) );
 ?>
 <?php get_template_part( 'inc/sub-header' ); ?>
@@ -18,7 +16,7 @@ $date = DateTime::createFromFormat( 'Ymd', get_field( 'event_date' ) );
 	<div id="content" role="main">
 	<?php if ( have_posts() ) : ?>
 	<div class="container container-fluid">
-	  <div class="row">
+	  <div class="row" id="mitlibnews-container" data-postcontent="category" data-postcategory="<?php echo esc_attr( get_query_var( 'cat' ) ); ?>">
 	      <?php
 	if ( is_category() ) {
 	 printf( '<h1 class="lib-header">' . 'Category: ' . '<strong>' . single_cat_title( '', false ) . '</strong>' . '</h1>' );
@@ -33,7 +31,7 @@ $date = DateTime::createFromFormat( 'Ymd', get_field( 'event_date' ) );
 	
 			<?php if ( get_post_type( get_the_ID() ) == 'bibliotech' ) { ?>
 		   
-			<?php } // End if(). ?>
+			<?php } ?>
 			  
 					<?php  wp_reset_query(); // Restore global post data stomped by the_post(). ?>
 		   

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -13,6 +13,8 @@
 		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
 		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Invalid" />
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing" />
 		<!-- Exclude the following known-failing sniffs -->
 		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedELSE" />
 		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />

--- a/inc/events.php
+++ b/inc/events.php
@@ -48,5 +48,5 @@
 			</span> 
 		  
 		   </div>
-		  <?php 	} // End if().	?>
+			<?php } // End if get_field event_date.	?>
 		  <!--EVENT --> 

--- a/index.php
+++ b/index.php
@@ -89,7 +89,7 @@ endif;
 	<div class="container container-fluid">
 
 		<!-- OPEN ROW FOR REGULAR CARD LAYOUT -->
-		<div class="row">
+		<div class="row" id="mitlibnews-container">
 
 <?php
 $args = array(
@@ -133,7 +133,7 @@ endif;
 <?php
 if ( $i > 6 ) {
 	get_template_part( 'inc/more-posts' );
-} // End if().
+}
 ?>
 
 </div>

--- a/js/src/mitlibnews.loader.js
+++ b/js/src/mitlibnews.loader.js
@@ -42,11 +42,15 @@ Loader.prototype = {
 	// Initialization
 	initialize : function() {
 		// Look up specified post container in DOM
+		console.log('Looking for ' + this.getContainer() );
 		this.postcontainer = document.getElementById( this.getContainer() );
 
 		// If no post container is found, then we quit and do nothing further.
 		if( !this.postcontainer ) {
+			console.log('Post container not found...');
 			return false;
+		} else {
+			console.log('Post container found. Continuing...');
 		}
 
 		// Read data attributes
@@ -68,12 +72,53 @@ Loader.prototype = {
 		var filter = {
 			'posts_per_page': this.getPagesize(),
 		};
+		var type = ['post', 'bibliotech', 'spotlights'];
 		// Context-specific values
 		if ( this.getPostcontent() === 'author' ) {
 			filter.author = this.postcontainer.dataset.postauthor;
+			// Author indexes don't show Spotlights
+			type = ['post', 'bibliotech'];
+		} else if ( this.getPostcontent() === 'bibliotech' ) {
+			// Only return bibliotech content
+			type = ['bibliotech'];
+		} else if ( this.getPostcontent() === 'category' ) {
+			query.categories = [this.postcontainer.dataset.postcategory];
+		} else if ( this.getPostcontent() === 'futureevents' ) {
+			// Only return post content
+			type = ['post'];
+			filter.meta_query = [{
+				'key': 'is_event',
+				'value': true,
+				'type': 'future',
+			}];
+		} else if ( this.getPostcontent() === 'issue' ) {
+			query.issue = this.postcontainer.dataset.postissue;
+			type = ['bibliotech'];
+		} else if ( this.getPostcontent() === 'news' ) {
+			// Only return post content
+			type = ['post'];
+			filter.meta_query = [{
+				'key': 'is_event',
+				'value': false,
+			}];
+		} else if ( this.getPostcontent() === 'pastevents' ) {
+			// Only return post content
+			type = ['post'];
+			filter.meta_query = [{
+				'key': 'is_event',
+				'value': true,
+				'type': 'past',
+			}];
+		} else if ( this.getPostcontent() === 'related' ) {
+			// Related queries are sorted randomly
+			filter.orderby = 'rand';
+			query.categories = [this.postcontainer.dataset.postcategory];
+		} else if ( this.getPostcontent() === 'search' ) {
+			query.search = this.postcontainer.dataset.search;
 		}
 		// Assemble pieces into query object
 		query.filter = filter;
+		query.type = type;
 		return query;
 	},
 
@@ -108,12 +153,13 @@ Loader.prototype = {
 
 		// Query the API
 		jQuery.ajax({
-			url: '/news/wp-json/posts',
+			url: '/news/wp-json/mitlibnews/v1/cards',
 			data: query,
 			dataType: 'json',
 			type: 'GET',
 			success: function(data) {
 				jQuery.each(data, function( index, value ) {
+					console.log('\n' + value.type + '\n' + value.title.rendered );
 					console.log(value);
 				});
 			},

--- a/js/tests/mitlibnews.loader.spec.js
+++ b/js/tests/mitlibnews.loader.spec.js
@@ -49,7 +49,8 @@ describe("Loader test suite", function() {
 			page: 1,
 			filter: {
 				posts_per_page: 9,
-			}
+			},
+			type: ['post', 'bibliotech', 'spotlights']
 		}
 		expect( test.buildQuery() ).toEqual(defaultQuery);
 	});

--- a/page-biblio-archive.php
+++ b/page-biblio-archive.php
@@ -59,7 +59,7 @@ if ( have_posts() ) {
 ?>
 	<p><?php esc_html_e( 'Sorry, no posts matched your criteria.' ); ?></p>
 <?php
-} // End if().
+} // End else clause.
 ?>
 
 		</div><!-- news-content -->

--- a/page-bibliotech.php
+++ b/page-bibliotech.php
@@ -50,7 +50,7 @@ while ( $query2->have_posts() ) : $query2->the_post(); ?>
 			
 				<?php wp_reset_query(); ?>
 		  
-					<?php } // End if(). ?>
+					<?php } ?>
 		 
 					<?php endwhile; ?>
 		
@@ -58,7 +58,7 @@ while ( $query2->have_posts() ) : $query2->the_post(); ?>
 						<div class="container container-fluid">
 			
 			<!-- OPEN ROW FOR MOBILE/STICKY CARD LAYOUT -->
-				<div class="row">  
+				<div class="row" id="mitlibnews-container" data-postcontent="bibliotech">  
 	
 			<?php
 $args = array(

--- a/page-events.php
+++ b/page-events.php
@@ -103,8 +103,8 @@ $the_archive = new WP_Query( $archive );
 $archive_posts = (array) $the_archive->posts;
 
 ?>
-	<div class="row">
 	<h1 class="events-header">Upcoming classes & events</h1>
+	<div class="row">
 	  <?php
 	  if ( count( $future_posts ) > 0 ) {
 		$i = -1;
@@ -123,7 +123,7 @@ $archive_posts = (array) $the_archive->posts;
 	<hr class="hidden-xs" />
 
 	<h2 class="padding-header">Past classes & events</h2>
-	<div class="row">
+	<div class="row" id="mitlibnews-container" data-postcontent="pastevents">
 	  <?php
 	  if ( count( $past_posts ) > 0 ) {
 		$i = -1;
@@ -146,9 +146,8 @@ $archive_posts = (array) $the_archive->posts;
 	
 	
 	
-	
 <script type="text/javascript">
-$(document).ready(function() {
+jQuery(document).ready(function() {
 	var offset = 11;
 	var limit = 9;
 	//$j("#postContainer").load("/news/add-posts-events/");
@@ -172,7 +171,6 @@ $(document).ready(function() {
 	});
 
 
-	
 
 });
 </script>

--- a/page-news.php
+++ b/page-news.php
@@ -22,7 +22,7 @@ get_header(); ?>
 				<div class="container container-fluid">
 			
 			<!-- OPEN ROW FOR REGULAR CARD LAYOUT -->
-				<div class="row"> 
+				<div class="row" id="mitlibnews-container" data-postcontent="news">
 	                
 	                <h1 class="events-header">News</h1>
 	

--- a/search.php
+++ b/search.php
@@ -15,9 +15,9 @@ get_header(); ?>
 <div id="primary" class="content-area">
 	<main id="main" class="content-main" role="main">
 	<div class="container">
-	<div class="row">
+	<h2 class="search">Search results for <strong><?php echo esc_html( get_search_query() ); ?></strong></h2>
+	<div class="row" id="mitlibnews-container" data-postcontent="search" data-search="<?php echo esc_attr( get_search_query() ); ?>">
 	
-	<h2 class="search">Search results for <strong><?php echo $_GET['s'] ?></strong></h2>
 
 	 <?php  if ( '' == $post ) { ?>
 		

--- a/single.php
+++ b/single.php
@@ -109,7 +109,7 @@ the_date(); ?> </span>
 			</span> 
 		  
 		   </div>
-		  <?php 	} // End if(). ?>
+			<?php } // End if get_field event_date. ?>
 
 	<!--=================image=================== -->       
 	<?php if ( get_field( 'image' ) ) { ?>
@@ -171,20 +171,21 @@ $catName = $category[ $r ]->cat_name;
 $currentPost = get_the_ID();
 
 
-$myCatId = $category[ $r ]->cat_ID;
+	$category_id = $category[ $r ]->cat_ID;
 
 $args = array(
 	'post_type' => array( 'post', 'bibliotech', 'spotlights' ),
-	'cat'          => $myCatId,
+	'cat'          => $category_id,
 	'posts_per_page'         => '3',
 	'order'                  => 'DESC',
 	'orderby'                => 'date',
 	'post__not_in'       => array( $currentPost ),
 );
-	?>
+
+?>
 	
 
-<div class="row">
+<div class="row" id="mitlibnews-container" data-postcontent="related" data-postcategory="<?php echo esc_attr( $category_id ); ?>" data-pagesize="3">
 <?php
 $myposts = get_posts( $args );
 $y = 1 ;

--- a/test-template.php
+++ b/test-template.php
@@ -82,7 +82,7 @@ echo '<a title="' . $category[0]->cat_name . '" href="' . get_category_link( $ca
 	</div>
 	<?php wp_reset_postdata(); ?>
 	<?php wp_reset_query(); ?>
-	  <?php  } // End if(). ?>
+	  <?php  } ?>
 	<?php endwhile; ?>
 	 <?php endif; ?>
 	
@@ -261,7 +261,7 @@ $thumb_url = $thumb_url_array[0];?>
 		  </p>
 		</div>
 		
-		<?php } // End if(). ?>
+		<?php } ?>
 		
 		<div class="category-post <?php  if ( get_post_type( get_the_ID() ) == 'bibliotech' ) { echo 'Bibliotech';} ?>">
 		


### PR DESCRIPTION
This adds markup to relevant pages so that the card loading plugin can configure itself correctly. It ends with the plugin logging the loaded content to the browser console. Future work will extend this code to include pagination control, as well as rendering the content as HTML.

Affected pages include:
- [x] Homepage (`/`)
- [x] News page (`/news`)
- [x] Events page (`/events`)
- [x] Single page (related posts)
- [x] Category pages (`/category/*`)
- [x] Bibliotech page (`/bibliotech-index/`)
- [ ] Search page (`/?s=`)

@frrrances - we've discussed this at intervals, but do you want to look over the code before I merge?