### PR TITLE
Forces jQuery to be loaded in the head element; closes NTI-97

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -16,7 +16,7 @@ foreach ( glob( $siteRoot . '/wp-content/themes/mit-libraries-news/lib/*.php' ) 
 function not_admin() {
 	wp_enqueue_style( 'bootstrapCSS', get_stylesheet_directory_uri() . '/css/bootstrap.css', 'false', '', false );
 	wp_enqueue_style( 'newsmobile', get_stylesheet_directory_uri() . '/css/newsmobile.css', 'false', '', false );
-	wp_enqueue_script( 'bootstrap','https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js', array( 'jquery' ), '3.3.1', true );
+	wp_enqueue_script( 'bootstrap','https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js', array( 'jquery' ), '3.3.1', false );
 }
 if ( ! is_admin() ) {
 	add_action( 'wp_enqueue_scripts', 'not_admin' );
@@ -35,8 +35,8 @@ add_action( 'wp_enqueue_scripts', 'add_styles' );
  * Add LazyLoad and MyScripts for all users
  */
 function add_scripts() {
-	wp_enqueue_script( 'lazyload', get_stylesheet_directory_uri() . '/js/lazyload.js', array( 'jquery' ), '', true );
-	wp_enqueue_script( 'myScripts', get_stylesheet_directory_uri() . '/js/myScripts.js', array( 'lazyload' ), '', true );
+	wp_enqueue_script( 'lazyload', get_stylesheet_directory_uri() . '/js/lazyload.js', array( 'jquery' ), '', false );
+	wp_enqueue_script( 'myScripts', get_stylesheet_directory_uri() . '/js/myScripts.js', array( 'lazyload' ), '', false );
 }
 add_action( 'wp_enqueue_scripts', 'add_scripts' );
 


### PR DESCRIPTION
The problem is that jQuery was being loaded in the page footer, rather than the `<head>` element - and there are inline scripts that were failing because jQuery hadn't appeared yet.

_sigh..._

This forces jQuery to be loaded in the header, but a follow-on task should be to treat the inline scripts properly.