### PR TITLE
Causes images to load on search results

### DIFF
--- a/js/myScripts.js
+++ b/js/myScripts.js
@@ -1,35 +1,13 @@
-
-
 (function($) {
-    
-	//lazy loading
-	$("img.img-responsive").lazyload({ 
-    effect : "fadeIn", 
-    effectspeed: 450 ,
-	failure_limit: 999999
-  }); 
 
- 	//category force selection of all news
+	//lazy loading
+	$("img.img-responsive").lazyload({
+		effect: "fadeIn",
+		effectspeed: 450,
+		failure_limit: 999999
+	});
+
+	//category force selection of all news
 	$('input:checkbox[id=in-category-43]').attr('checked',true);
 
 })(jQuery);
-
-
-
-
-
-
-  
-  
-
-
-	
-
-  
-  
-  
-  
-
-	
-
-

--- a/search.php
+++ b/search.php
@@ -124,6 +124,7 @@ $(document).ready(function() {
 	var limit = 0;
 	var car = "<?php echo $_GET[ s ]; ?>";
 	var car = encodeURIComponent(car);
+	$("#postContainer").load("/news/search-results/");
 	$("#another").click(function(){
 	limit = limit + 18;
 	$("#postContainer")


### PR DESCRIPTION
Adds initial call to fake-API, triggering lazyload plugin.

I'm not sure why this is necessary. The call to LazyLoad is also in `js/myScripts.js`, but for some reason it isn't working there. Other page templates, like `index.php` and `page-news.php` use the technique added here - an initial call to the fake-API, which has the effect of triggering LazyLoad. So this at least makes the theme more consistent, if also more WTF.