### PR TITLE
Update single news item ul style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1576,13 +1576,13 @@ p.search {
 
 
 
-.single ul li {
+.single .mitContent ul li {
 	list-style-type: disc;
 }
-.single li {
+.single .mitContent li {
 	margin-bottom: 5px;
 }
-.single ul.sIcons li {
+.single .mitContent ul.sIcons li {
 	list-style-type: none
 }
 .btn-default:hover, .btn-default:focus, .btn-default.focus, .btn-default:active, .btn-default.active, .open > .dropdown-toggle.btn-default {


### PR DESCRIPTION
The ul style for single news item was overriding the navigation ul
settings and causing bullets to appear. This change restricts the style
to the content area