### PR TITLE
Changes how Bibliotech archive template loads images

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -62,7 +62,7 @@ if ( (get_post_type( get_the_ID() ) == 'bibliotech') || (cat_is_ancestor_of( 73,
 	   
 		<?php
 		if ( get_field( 'listImg' ) != '' ) { ?>
-		<img data-original="<?php the_field( 'listImg' ) ?>" width="100%" height="111" class="img-responsive"  alt="<?php the_title(); ?>"/>
+		<img src="<?php the_field( 'listImg' ); ?>" width="100%" height="111" class="img-responsive" alt="<?php the_title(); ?>"/>
 		<?php } ?>
 		
 		


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This changes how the Bibliotech Archive template loads images. 

#### Helpful background context (if appropriate)
The theme uses a LazyLoad library to bring in images only once they're on the screen. This is achieved by using the `data-original` attribute when additional posts are added via AJAX, but the first page load should still use the traditional `src` attribute.

It appears that the Bibliotech Archive template didn't properly implement this logic, and instead was using `data-original` on the initial page load.

**Note**: Travis is failing because of reasons unrelated to this change. CodeClimate appears to be better scoped for this PR.

#### How can a reviewer manually see the effects of these changes?
Compare these two URLs:
Production (with bug) https://libraries.mit.edu/news/bibliotech_issues/fall-2017/
Test (bug fixed) https://libraries-test.mit.edu/news/bibliotech_issues/spring-2016/

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-194

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
