### PR TITLE
Fixes incorrect parsing of 'blank' string fields that are always present

### DIFF
--- a/additionalPosts-archives.php
+++ b/additionalPosts-archives.php
@@ -79,8 +79,8 @@ $i++;
 
 
 	<div class="<?php if ( 0 === $i % 3 ) { echo 'third '; } ?> col-xs-12  col-xs-B-6 col-sm-4 col-md-4 no-padding-left-mobile">
-		<div class="flex-item blueTop eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ('' !== get_field( 'external_link' )) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+		<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
+			onClick='location.href="<?php if ( ('' !== get_field( 'external_link' )) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 		<?php
 		if ( '' !== get_field( 'listImg' ) ) { ?>

--- a/additionalPosts-search.php
+++ b/additionalPosts-search.php
@@ -88,8 +88,8 @@ while ( $the_query->have_posts() ) : $the_query->the_post();
 
 
 	<div id="theBox" class="<?php if ( 0 == $o % 3 ) { echo 'third '; } ?> col-xs-12  col-xs-B-6 col-sm-4 col-md-4 no-padding-left-mobile">
-	  <div class="flex-item blueTop  eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+	  <div class="flex-item blueTop  eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'> 
 		<?php get_template_part( 'inc/spotlights' ); ?>
 	   

--- a/archive-bibliotech.php
+++ b/archive-bibliotech.php
@@ -68,8 +68,8 @@ function the_excerpt_max_charlength( $charlength ) {
 	<!-- .archive-header -->
 	<div class="mit-container">
 	  <?php while ( have_posts() ) : the_post(); ?>
-	  <div class="flex-item blueTop eventsBox <?php if ( ! has_post_thumbnail() ) { echo 'no-image';
-} else { echo 'has-image'; } ?>" onClick='location.href="<?php echo get_post_permalink(); ?>"'>
+	  <div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php echo get_post_permalink(); ?>"'>
 		<?php if ( get_field( 'mark_as_new' ) === true ) : ?>
 		<?php endif; ?>
 		<?php if ( has_post_thumbnail() ) {

--- a/archive.php
+++ b/archive.php
@@ -51,8 +51,8 @@ if ( (get_post_type( get_the_ID() ) == 'bibliotech') || (cat_is_ancestor_of( 73,
 	  ?>
 	  
 	  <div class="<?php if ( 0 == $i % 3 ) { echo 'third '; } ?> col-xs-12  col-xs-B-6 col-sm-4 col-md-4 no-padding-left-mobile">
-	  <div class="hentry flex-item blueTop eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+	  <div class="hentry flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 
 

--- a/author.php
+++ b/author.php
@@ -78,8 +78,8 @@ get_header(); ?>
 			?>
 				
 				   <div id="theBox" class="<?php if ( 0 == $i % 3 ) { echo 'third '; } ?>no-padding-left-mobile col-xs-12 col-xs-B-6 col-sm-4 col-md-4 col-lg-4">
-	  <div class="flex-item blueTop  eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+	  <div class="flex-item blueTop  eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 		  
 		  

--- a/css/style.css
+++ b/css/style.css
@@ -4,7 +4,7 @@
 	Description: A Wordpress child theme that descends from mitlibraries-parent
 	Author: Design by Moth Design, development by MIT Libraries
 	Template: libraries
-	Version: 1.6.0-@@branch-@@commit;
+	Version: 1.6.1-@@branch-@@commit;
 */
 
 @import url("../libraries/style.css");

--- a/lib/cards.php
+++ b/lib/cards.php
@@ -274,7 +274,7 @@ function renderRegularCard( $i, $post ) {
 		        <?php
 				if ( get_field( 'listImg' ) != '' ) { ?>
 		    	<?php get_template_part( 'inc/image' ); ?>
-				<?php } elseif ( '' !== get_field( 'calendar_image' ) ) { ?>
+				<?php } elseif ( strlen( get_field( 'calendar_image' ) ) > 0 ) { ?>
 				<?php get_template_part( 'inc/imageEvent' ); ?>
 		        <?php } ?><!-- .listImg -->  
 
@@ -345,7 +345,7 @@ function renderEventCard( $i, $post ) {
 		        <?php
 				if ( get_field( 'listImg' ) != '' ) { ?>
 		    	<?php get_template_part( 'inc/image' ); ?>
-				<?php } elseif ( get_field( 'calendar_image' ) !== '' ) { ?>
+				<?php } elseif ( strlen( get_field( 'calendar_image' ) ) > 0 ) { ?>
 				<?php get_template_part( 'inc/imageEvent' ); ?>
 		        <?php } ?><!-- .listImg -->  
 

--- a/lib/cards.php
+++ b/lib/cards.php
@@ -7,6 +7,22 @@
  */
 
 /**
+ * This returns either "no-image" or "has-image" based on whether a post has an image or not.
+ *
+ * @param object $post A WP post object.
+ */
+function check_image( $post ) {
+	$result = 'no-image';
+	// There are two possible fields that would have an image.
+	// listImg is for locally-declared images.
+	// calendar_image is for images imported from the MIT Calendar.
+	if ( get_field( 'listImg' ) || get_field( 'calendar_image' ) ) {
+		$result = 'has-image';
+	}
+	return $result;
+}
+
+/**
  * Render function
  *
  * @param object $post A WP post object.
@@ -20,12 +36,8 @@ function render( $post, $i, $type ) {
 	$outerClasses .= ' third';
 	}
 	// Default inner classes.
-	$innerClasses = 'flex-item blueTop eventsBox render-confirm-' . $type;
-	if ( get_field( 'listImg' ) ) {
-	$innerClasses .= ' has-image';
-	} else {
-	$innerClasses .= ' no-image';
-	}
+	$innerClasses = 'flex-item blueTop eventsBox render-confirm-' . $type . ' ' . check_image( $post );
+
 	// Inner onClick.
 	$innerOnClick = '';
 	if ( '' != get_field( 'external_link' ) && 'spotlights' == $post->post_type ) {
@@ -104,8 +116,8 @@ function render( $post, $i, $type ) {
 function renderMobileCard( $i, $post ) {
 ?>
 <div  class="visible-xs visible-sm hidden-md hidden-lg no-padding-left-mobile no-padding-left-tablet col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4 ">
-<div class="flex-item blueTop eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image( $post ) ); ?>"
+	onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	
 	   		<!-- INTERNAL CONTAINER TO CONTROL FOR OVERFLOW -->   
@@ -158,8 +170,8 @@ function renderMobileCard( $i, $post ) {
 function renderMobileBiblioCard( $i, $post ) {
 ?>
 <div  class="visible-xs visible-sm hidden-md hidden-lg no-padding-left-mobile no-padding-left-tablet col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4 ">
-<div class="flex-item blueTop eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image( $post ) ); ?>"
+	onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	
 	   		<!-- INTERNAL CONTAINER TO CONTROL FOR OVERFLOW -->   
@@ -202,8 +214,8 @@ function renderMobileBiblioCard( $i, $post ) {
 function renderBiblioCard( $m, $post ) {
 ?>
 <div  class="no-padding-left-mobile col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4">
-<div class="flex-item blueTop eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image( $post ) ); ?>"
+	onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	
 	   		<!-- INTERNAL CONTAINER TO CONTROL FOR OVERFLOW -->   
@@ -256,10 +268,11 @@ function renderRegularCard( $i, $post ) {
 		 $post_link = get_field( 'calendar_url' );
 	}
 
+	$image_class = check_image( $post );
+
 ?>
 <div id="theBox" class="no-padding-left-mobile col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4">
-<div class="flex-item blueTop eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" 
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( $image_class ); ?>" 
 	onClick='location.href="<?php echo esc_url( $post_link ); ?>"'
 	>
 	   		<!-- INTERNAL CONTAINER TO CONTROL FOR OVERFLOW -->   
@@ -329,10 +342,7 @@ function renderEventCard( $i, $post ) {
 		$event_link = get_field( 'calendar_url' );
 	}
 
-	$image_class = 'no-image';
-	if ( get_field( 'listImg' ) || get_field( 'calendar_image' ) ) {
-		$image_class = 'has-image';
-	}
+	$image_class = check_image( $post );
 ?>
 	<div id="theBox" class="col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4">
 	<div itemscope itemtype="http://data-vocabulary.org/Event"

--- a/lib/cards.php
+++ b/lib/cards.php
@@ -8,14 +8,12 @@
 
 /**
  * This returns either "no-image" or "has-image" based on whether a post has an image or not.
- *
- * @param object $post A WP post object.
+ * This is done by checking two custom fields:
+ * listImg is for locally-declared images.
+ * calendar_immage is for images imported from the MIT Calendar.
  */
-function check_image( $post ) {
+function check_image() {
 	$result = 'no-image';
-	// There are two possible fields that would have an image.
-	// listImg is for locally-declared images.
-	// calendar_image is for images imported from the MIT Calendar.
 	if ( get_field( 'listImg' ) || get_field( 'calendar_image' ) ) {
 		$result = 'has-image';
 	}
@@ -36,7 +34,7 @@ function render( $post, $i, $type ) {
 	$outerClasses .= ' third';
 	}
 	// Default inner classes.
-	$innerClasses = 'flex-item blueTop eventsBox render-confirm-' . $type . ' ' . check_image( $post );
+	$innerClasses = 'flex-item blueTop eventsBox render-confirm-' . $type . ' ' . check_image();
 
 	// Inner onClick.
 	$innerOnClick = '';
@@ -116,7 +114,7 @@ function render( $post, $i, $type ) {
 function renderMobileCard( $i, $post ) {
 ?>
 <div  class="visible-xs visible-sm hidden-md hidden-lg no-padding-left-mobile no-padding-left-tablet col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4 ">
-<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image( $post ) ); ?>"
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
 	onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	
@@ -170,7 +168,7 @@ function renderMobileCard( $i, $post ) {
 function renderMobileBiblioCard( $i, $post ) {
 ?>
 <div  class="visible-xs visible-sm hidden-md hidden-lg no-padding-left-mobile no-padding-left-tablet col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4 ">
-<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image( $post ) ); ?>"
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
 	onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	
@@ -214,7 +212,7 @@ function renderMobileBiblioCard( $i, $post ) {
 function renderBiblioCard( $m, $post ) {
 ?>
 <div  class="no-padding-left-mobile col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4">
-<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image( $post ) ); ?>"
+<div class="flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
 	onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	
@@ -268,7 +266,7 @@ function renderRegularCard( $i, $post ) {
 		 $post_link = get_field( 'calendar_url' );
 	}
 
-	$image_class = check_image( $post );
+	$image_class = check_image();
 
 ?>
 <div id="theBox" class="no-padding-left-mobile col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4">
@@ -342,7 +340,7 @@ function renderEventCard( $i, $post ) {
 		$event_link = get_field( 'calendar_url' );
 	}
 
-	$image_class = check_image( $post );
+	$image_class = check_image();
 ?>
 	<div id="theBox" class="col-xs-12 col-xs-B-6 col-sm-6 col-md-4 col-lg-4">
 	<div itemscope itemtype="http://data-vocabulary.org/Event"

--- a/page-last-year.php
+++ b/page-last-year.php
@@ -72,8 +72,8 @@ $the_query = new WP_Query( $args );
 	<div class="mit-container">
 	  <?php if ( $the_query->have_posts() ) :   ?>
 	  <?php while ( $the_query->have_posts() ) : $the_query->the_post();  ?>
-	  <div class="flex-item eventsBox <?php if ( ! has_post_thumbnail() ) { echo 'no-image';
-} else { echo 'has-image'; } ?>" onClick='location.href="<?php echo get_post_permalink(); ?>"'>
+	  <div class="flex-item eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php echo get_post_permalink(); ?>"'>
 		<?php if ( get_field( 'mark_as_new' ) === true ) : ?>
 		<?php endif; ?>
 		<?php if ( has_post_thumbnail() ) {

--- a/search.php
+++ b/search.php
@@ -41,8 +41,8 @@ $L++;
 	  	?>
 	  <!--//////////// -->
 	  <div id="theBox" class="<?php if ( 0 == $L % 3 ) { echo 'third '; } ?>col-xs-12 col-xs-B-6 col-sm-4 col-md-4 col-lg-4 no-padding-left-mobile">
-	  <div class="hentry flex-item blueTop  eventsBox <?php if ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+	  <div class="hentry flex-item blueTop  eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 		  
 		  

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
 	Description: A Wordpress child theme that descends from mitlibraries-parent
 	Author: Design by Moth Design, development by MIT Libraries
 	Template: libraries
-	Version: 1.6.0-@@branch-@@commit;
+	Version: 1.6.1-@@branch-@@commit;
 
 News theme built for the MIT Libraries.
 

--- a/test-template.php
+++ b/test-template.php
@@ -123,9 +123,8 @@ $the_query = new WP_Query( $args );
 
 	  ?>
 	<div class="col-xs-12 col-sm-4 col-md-4">
-	  <div class="hentry flex-item blueTop eventsBox <?php if ( has_post_thumbnail() ) { echo 'has-image';
-} elseif ( get_field( 'listImg' ) ) { echo 'has-image';
-} else { echo 'no-image'; } ?>" onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
+	  <div class="hentry flex-item blueTop eventsBox <?php echo esc_attr( check_image() ); ?>"
+		onClick='location.href="<?php if ( ( '' != get_field( 'external_link' ) ) && 'spotlights' == $post->post_type ) { the_field( 'external_link' );
 } else { echo get_post_permalink();}  ?>"'>
 	<?php if ( 'spotlights' == $post->post_type ) { ?>
 		<div class="featuredCol">Featured collection</div>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adjusts how cards are displayed on the News theme in two ways:
1) Spotlight cards, which usually display only a single sentence of text, are positioned correctly top-to-bottom on the card
2) The logic behind when cards get a blue bar at the top is corrected to account for the fact that images are now stored in two fields rather than just one.

#### Helpful background context (if appropriate)
These changes are made necessary because we recently added the ability to import records from the MIT Calendar, which means that the possible local configurations for news stories have gotten more complex. In order to anticipate this richer variety of local content, we are discovering some less-than-optimal code design for how these cards are rendered.

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-227

#### Screenshots (if appropriate)
Imported event card, seen on the front page, with an incorrectly-applied blue bar (because the display logic only looks for one of two possible fields that could store an image)
Seen on: https://libraries.mit.edu/news/ (you may need to hit the "See More" link a few times to bring this in view)
![image](https://user-images.githubusercontent.com/1403248/34127415-0ee6ffd2-e40b-11e7-8d5f-6973bc376641.png)

The same imported event card when viewed under this new code. Seen on the development news site at path `/news/` (you may need to hit the "See More" link a few times to bring this in view)
![image](https://user-images.githubusercontent.com/1403248/34127468-3f7be25c-e40b-11e7-922e-f9c851e9c04a.png)

Spotlight card (with only one sentence of text) rendered via the master branch. The sentence appears too low because of some faulty logic checking for blank/empty fields.
![image](https://user-images.githubusercontent.com/1403248/34127508-6e595776-e40b-11e7-945e-0502be305f3b.png)

Spotlight card when rendered by this branch. This sentence is now correctly positioned vertically because the logic checking for empty fields is now more approriate.
![image](https://user-images.githubusercontent.com/1403248/34127558-9e9ac848-e40b-11e7-9f06-42ca9ab20a35.png)


#### Todo:
- [ ] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
