### PR TITLE
Simple modification of posts in feeds with custom tag

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -280,6 +280,24 @@ function eventRSSFunc() {
 }
 
 /**
+ * Override the permalink in RSS displays for event posts
+ */
+function mitlib_alter_rss_permalink() {
+	global $post;
+	$url = $post->guid;
+	if ( 'post' === get_post_type() ) {
+		$is_event = get_post_meta( get_the_ID(), 'is_event' );
+		if ( '1' === $is_event[0] ) {
+			// This post has been marked as an event.
+			$calendar_url = get_post_meta( get_the_ID(), 'calendar_url' );
+			$url = $calendar_url[0];
+		}
+	}
+	return $url;
+}
+add_filter( 'the_permalink_rss', 'mitlib_alter_rss_permalink' );
+
+/**
  * Customize meta boxes on admin interface
  */
 function customize_meta_boxes() {

--- a/functions.php
+++ b/functions.php
@@ -285,13 +285,9 @@ function eventRSSFunc() {
 function mitlib_alter_rss_permalink() {
 	global $post;
 	$url = $post->guid;
-	if ( 'post' === get_post_type() ) {
-		$is_event = get_post_meta( get_the_ID(), 'is_event' );
-		if ( '1' === $is_event[0] ) {
-			// This post has been marked as an event.
-			$calendar_url = get_post_meta( get_the_ID(), 'calendar_url' );
-			$url = $calendar_url[0];
-		}
+	// If the post has an MIT Calendar URL specified, we use that instead.
+	if ( 'post' === get_post_type() && get_post_meta( get_the_ID(), 'calendar_url', true ) ) {
+		$url = get_post_meta( get_the_ID(), 'calendar_url', true );
 	}
 	return $url;
 }

--- a/rss-event.php
+++ b/rss-event.php
@@ -68,7 +68,7 @@ echo '<?xml version="1.0"?>';
 
 	<item>
 	<title><?php echo get_the_title( $post->ID ); ?></title>
-	<link><?php echo get_permalink( $post->ID ); ?></link>
+	<link><?php the_permalink_rss( $post->ID ); ?></link>
 	<description><?php echo '<![CDATA[' . yoast_rss_text_limit( $post->post_content, 500 ) . '<br/><br/>Keep on reading: <a href="' . get_permalink( $post->ID ) . '">' . get_the_title( $post->ID ) . '</a>' . ']]>';  ?></description>
 	<pubDate><?php yoast_rss_date( strtotime( $post->post_date_gmt ) ); ?></pubDate>
 	<guid><?php echo get_permalink( $post->ID ); ?></guid>

--- a/single.php
+++ b/single.php
@@ -111,6 +111,13 @@ the_date(); ?> </span>
 		   </div>
 		  <?php 	}	?>
 
+	<?php
+	if ( get_field( 'calendar_url' ) ) {
+		$calendar_url = get_field( 'calendar_url' );
+		echo '<h2>For more about this event, please visit <a href="' . esc_url( $calendar_url ) . '">' . esc_url( $calendar_url ) . '</a></h2>';
+	}
+	?>
+
 	<!--=================image=================== -->       
 	<?php if ( get_field( 'image' ) ) { ?>
 	 <div class="mySinglePicMobile hidden-md hidden-lg col-xs-12">


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a filter for permalinks in the RSS feeds. If the `calendar_url` meta field has been specified, the RSS feed will use that as the permalink instead of the internal Wordpress post URL.

#### Helpful background context (if appropriate)
This fix makes one assumption regarding how content is stored on the News site. The theme combines news articles and event records in the same post type (`post`), which are differentiated in some contexts by a custom `is_event` field. I'm choosing to _ignore_ that field in this fix, and check only the `calendar_url` field. My logic is that, in this case, the `is_event` field is irrelevant. Should a non-event post ever need a value in the `calendar_url` field, that should be enough to trigger the override.

The risk is that, if a non-event post ever records a `calendar_url` value and this override is not desired, this PR would cause a problem. However, I don't think this scenario is likely - and the performance benefit of not making an additional call to `get_post_meta()` is worthwhile.

#### How can a reviewer manually see the effects of these changes?
View the RSS feeds from the News theme ( /news/category/1/feed/ or /news/events-feed/ on the test site ), and look at the permalink for event posts. They should point to calendar.mit.edu, not the News site.

Also, the display of the event post itself should now have a link to whatever URL is specified in the `calendar_url` field.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-264
- https://help.mit.edu/Ticket/Display.html?id=4482483

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
