### PR TITLE
Escapes echoing of search string

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,7 +4,7 @@
 	Description: A Wordpress child theme that descends from mitlibraries-parent
 	Author: Design by Moth Design, development by MIT Libraries
 	Template: libraries
-	Version: 1.6.2-@@branch-@@commit;
+	Version: 1.6.3-@@branch-@@commit;
 */
 
 @import url("../libraries/style.css");

--- a/search.php
+++ b/search.php
@@ -6,18 +6,19 @@
  * @since Twenty Twelve 1.0
  */
 
-get_header(); ?>
-<?php get_template_part( 'inc/sub-header' ); ?>
+get_header();
 
+get_template_part( 'inc/sub-header' );
 
-
+$search_query = get_search_query();
+?>
 
 <div id="primary" class="content-area">
 	<main id="main" class="content-main" role="main">
 	<div class="container">
 	<div class="row">
 	
-	<h2 class="search">Search results for <strong><?php echo esc_html( $_GET['s'] ); ?></strong></h2>
+	<h2 class="search">Search results for <strong><?php echo esc_html( $search_query ); ?></strong></h2>
 
 	 <?php  if ( '' == $post ) { ?>
 		
@@ -122,7 +123,7 @@ $L++;
 $(document).ready(function() {
 	var offset = 9;
 	var limit = 0;
-	var car = "<?php echo esc_html( $_GET['s'] ); ?>";
+	var car = "<?php echo esc_html( $search_query ); ?>";
 	var car = encodeURIComponent(car);
 	$("#postContainer").load("/news/search-results/");
 	$("#another").click(function(){

--- a/search.php
+++ b/search.php
@@ -17,7 +17,7 @@ get_header(); ?>
 	<div class="container">
 	<div class="row">
 	
-	<h2 class="search">Search results for <strong><?php echo $_GET['s'] ?></strong></h2>
+	<h2 class="search">Search results for <strong><?php echo esc_html( $_GET['s'] ); ?></strong></h2>
 
 	 <?php  if ( '' == $post ) { ?>
 		
@@ -122,7 +122,7 @@ $L++;
 $(document).ready(function() {
 	var offset = 9;
 	var limit = 0;
-	var car = "<?php echo $_GET[ s ]; ?>";
+	var car = "<?php echo esc_html( $_GET['s'] ); ?>";
 	var car = encodeURIComponent(car);
 	$("#postContainer").load("/news/search-results/");
 	$("#another").click(function(){

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
 	Description: A Wordpress child theme that descends from mitlibraries-parent
 	Author: Design by Moth Design, development by MIT Libraries
 	Template: libraries
-	Version: 1.6.2-@@branch-@@commit;
+	Version: 1.6.3-@@branch-@@commit;
 
 News theme built for the MIT Libraries.
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This closes an XSS vulnerability in the news theme where search strings were not escaped before being rendered on the search page. This allowed attackers to insert and have executed code of their choosing.

#### How can a reviewer manually see the effects of these changes?
There is a proof-of-concept URL in the RequestTracker ticket - use that against a site running this branch, and compare to site behavior when running that search against other sites on the Wordpress network.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-272
- Ticket 4488942 in RequestTracker

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
