### PR TITLE
Fix spotlight feed external link

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -280,7 +280,7 @@ function eventRSSFunc() {
 }
 
 /**
- * Override the permalink in RSS displays for event posts
+ * Override the permalink in RSS displays for event posts and spotlights
  */
 function mitlib_alter_rss_permalink() {
 	global $post;
@@ -288,6 +288,9 @@ function mitlib_alter_rss_permalink() {
 	// If the post has an MIT Calendar URL specified, we use that instead.
 	if ( 'post' === get_post_type() && get_post_meta( get_the_ID(), 'calendar_url', true ) ) {
 		$url = get_post_meta( get_the_ID(), 'calendar_url', true );
+	} // If the post has an external link specified, we use that instead.
+	elseif ( 'spotlights' === get_post_type() && get_post_meta( get_the_ID(), 'external_link', true ) ) {
+		$url = get_post_meta( get_the_ID(), 'external_link', true );
 	}
 	return $url;
 }


### PR DESCRIPTION
#### What does this PR do?
Uses the external link for spotlight stories in the RSS feed. 

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Changes are up on test. You can see the top story now links to news.mit.edu instead of the libraries news site. 
https://libraries-test.mit.edu/news/category/library-spaces/feed/

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-483
