### PR TITLE
Refactor OpenGraph attributes from Parent

### DIFF
--- a/inc/header-opengraph.php
+++ b/inc/header-opengraph.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * The OpenGraph (or other social integration) metadata for a page.
+ *
+ * This is an override of the same template from the Parent theme.
+ *
+ * @package MIT_Libraries_Parent
+ * @since 1.6.5
+ */
+
+?>
+<?php
+/**
+ * We need to load the global $wp object in order to accurately render the
+ * current URL.
+ */
+global $wp;
+
+/**
+ * We need the global $post object to load page content, because we aren't
+ * in The Loop yet.
+ * Reference: https://codex.wordpress.org/Class_Reference/WP_Post
+ */
+global $post;
+
+// Render non-image fields now...
+?>
+<meta property="og:title" content="<?php wp_title( '|', true, 'right' ); ?>" />
+<meta property="og:type" content="website" />
+<meta property="og:description" content="<?php echo esc_attr( ( $post->excerpt ) ? $post->excerpt : wp_trim_excerpt( $post->id ) ); ?>" />
+<meta property="og:url" content="<?php echo esc_url( home_url( $wp->request ) . '/' ); ?>">
+<?php
+
+// Sigh... render the image separately, as that is complicated.
+if ( '' !== get_field( 'featuredListImg' ) ) {
+	?>
+	<meta property="og:image" content="<?php the_field( 'featuredListImg' ); ?>" />
+	<meta property="og:image:alt" content="<?php wp_title( '|', true, 'right' ); ?>" />
+	<?php
+} else {
+	?>
+	<meta property="og:image" content="<?php echo esc_url( get_template_directory_uri() . '/images/mit-libraries-logo-black-yellow-1200-1200.png', 'https' ); ?>"/>
+	<meta property="og:image:type" content="image/png" />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="1200" />
+	<meta property="og:image:alt" content="MIT Libraries logo" />
+	<?php
+}


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This PR leverages work from the Parent theme to make OpenGraph meta tags more accurate and complete.

Taking the `inc/header-opengraph.php` partial that is established in MITLibraries/MITlibraries-parent#323, this work overrides that template with one that anticipates fields specific to the News theme.

Because of Facebook's requirements for minimum image sizes, most of our image surrogates are too small to be used. However, those generated for the featured image block - `featuredListImg` - are large enough. Where this image is present, we use it instead of the default value of the Libraries' network logo.

#### How can a reviewer manually see the effects of these changes?
This branch has been deployed to staging. it should result in no visible changes in a browser.

To see the difference, try sharing news articles from the Staging site in either Facebook or Slack.

https://developers.facebook.com/tools/debug/ is a useful tool for previewing how Facebook will see these attributes. You can also paste a URL directly into Slack and see how it appears there.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-949

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES - this PR requires the related Parent PR to have already been deployed. Otherwise it will have no effect.

#### Requires change to deploy process?
NO
